### PR TITLE
Shorten string in tooltip if too long

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,6 @@
     <body>
         <div id="text-card-container">
             <div id="text-card"></div>
-            <div id="text-card-sidebar"></div>
         </div>
         <script id="spotfire-loader">
             var Spotfire = (function (e) {

--- a/src/main.js
+++ b/src/main.js
@@ -643,6 +643,12 @@ function createTooltipString(specificRow, tooltipContent) {
             //Handle date
             dataValue = formatDate(new Date(Number(dataValue)));
 
+        // truncate to a max length of 100 characters per tooltip row
+        var maxLength = 100;
+        if (typeof dataValue === "string" && dataValue.length > maxLength) {
+            dataValue = truncateString(dataValue, maxLength);
+        }
+
         var tooltipObj = {
             columnName: columnName,
             dataValue: dataValue
@@ -719,4 +725,9 @@ function configureMouseOver(divObject, borderDiv, fontStyling, row, tooltipEnabl
     divObject.header.onmouseleave = (e) => {
         mod.controls.tooltip.hide();
     };
+}
+
+function truncateString(dataValue, maxLength) {
+    // Slice at maxLength minus 3 to really return maxLength characters
+    return dataValue.slice(0, maxLength - 3) + "...";
 }


### PR DESCRIPTION
Truncate string in tooltip to 100 characters when too long
Fixes #128