### PR TITLE
Fix for marking

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -304,14 +304,14 @@ function renderTextCards(rows, prevIndex, cardsToLoad, rerender, windowSize, mod
     styleElement.appendChild(
         document.createTextNode(
             "::-webkit-scrollbar {width: 8px;} ::-webkit-scrollbar-track {border-radius: 16px; background-color: " +
-                scalesStyling.lineColor +
-                "4d;} ::-webkit-scrollbar-thumb {border-radius: 16px; background-color: " +
-                fontStyling.fontColor +
-                "4d;} ::-webkit-scrollbar-thumb:hover {background-color: " +
-                fontStyling.fontColor +
-                "BF;} ::-webkit-scrollbar-thumb:active {background-color: " +
-                fontStyling.fontColor +
-                "BF;}"
+            scalesStyling.lineColor +
+            "4d;} ::-webkit-scrollbar-thumb {border-radius: 16px; background-color: " +
+            fontStyling.fontColor +
+            "4d;} ::-webkit-scrollbar-thumb:hover {background-color: " +
+            fontStyling.fontColor +
+            "BF;} ::-webkit-scrollbar-thumb:active {background-color: " +
+            fontStyling.fontColor +
+            "BF;}"
         )
     );
     document.getElementsByTagName("head")[0].appendChild(styleElement);
@@ -390,7 +390,14 @@ function renderTextCards(rows, prevIndex, cardsToLoad, rerender, windowSize, mod
                 var selectedText = getSelectedText();
                 if (selectedText === "") {
                     e.stopPropagation();
-                    rows[index].mark("Toggle");
+                    if (!e.ctrlKey) {
+                        rows[index].mark("Replace");
+                    } else {
+                        if (rows[index].isMarked) {
+                            rows[index].mark("Toggle");
+                        }
+                        rows[index].mark("Add");
+                    }
                 }
             };
 


### PR DESCRIPTION
If something is already marked, and the user marks something else, this
becomes a new marking, instead of being added to the marking.

User can now ctrl + click to add to the current markin,
just like in the native visualizations on spotfire.
If ctrl + click on an already selected card, it is removed,
just like the native ones.