### PR TITLE
Add overflow-wrap to avoid long words breaking the design

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -78,6 +78,10 @@ body {
     padding-right: 24px;
     overflow-y: auto;
     overflow-x: hidden;
+    overflow-wrap: break-word;
+    /*-webkit-hyphens: auto;
+    -moz-hyphens: auto;
+         hyphens: auto; */
 }
 
 #img-button {


### PR DESCRIPTION
- splits long words/strings (without breakpoint) into a new row.
- avoids breaking the design
- no hyphens are used, words not breaking the text card box are moved to next line 

Fixes #223